### PR TITLE
Make istio control plane use socket to fetch its certificates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.11.0
+	github.com/spiffe/go-spiffe/v2 v2.1.0
 	github.com/vishvananda/netlink v1.2.0-beta
 	github.com/yl2chen/cidranger v1.0.2
 	go.opencensus.io v0.23.0
@@ -117,6 +118,7 @@ require (
 	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/VividCortex/ewma v1.1.1 // indirect
@@ -227,6 +229,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
+	github.com/zeebo/errs v1.2.2 // indirect
 	go.starlark.net v0.0.0-20211013185944-b0039bd2cfe3 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f // indirect

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,7 @@ github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JP
 github.com/Microsoft/go-winio v0.4.17-0.20210324224401-5516f17a5958/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7-0.20190325164909-8abdbb8205e4/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
@@ -1945,6 +1946,8 @@ github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH
 github.com/spf13/viper v1.9.0/go.mod h1:+i6ajR7OX2XaiBkrcZJFK21htRk7eDeLg7+O6bhUPP4=
 github.com/spf13/viper v1.11.0 h1:7OX/1FS6n7jHD1zGrZTM7WtY13ZELRyosK4k93oPr44=
 github.com/spf13/viper v1.11.0/go.mod h1:djo0X/bA5+tYVoCn+C7cAYJGcVn/qYLFTG8gdUsX7Zk=
+github.com/spiffe/go-spiffe/v2 v2.1.0 h1:IZRlWhyFpPbJOiK8K+MwEFPU/QCdaW4Zf5bmIKBd3XM=
+github.com/spiffe/go-spiffe/v2 v2.1.0/go.mod h1:5qg6rpqlwIub0JAiF1UK9IMD6BpPTmvG6yfSgDBs5lg=
 github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
@@ -2088,6 +2091,8 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
+github.com/zeebo/errs v1.2.2 h1:5NFypMTuSdoySVTqlNs1dEoU21QVamMQJxW/Fii5O7g=
+github.com/zeebo/errs v1.2.2/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -2900,6 +2905,7 @@ google.golang.org/genproto v0.0.0-20200626011028-ee7919e894b5/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200707001353-8e8330bf89df/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -3002,6 +3008,7 @@ google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACu
 google.golang.org/grpc v1.46.2 h1:u+MLGgVf7vRdjEYZ8wDFhAVNmhkbJ5hmrA1LMWK1CAQ=
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/examples v0.0.0-20201130180447-c456688b1860/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -3046,6 +3053,7 @@ gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.4.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
 gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/deployment.yaml
@@ -179,6 +179,8 @@ spec:
               drop:
               - ALL
           volumeMounts:
+          - name: workload-socket
+            mountPath: /var/run/secrets/workload-spiffe-uds
           {{- if eq .Values.global.jwtPolicy "third-party-jwt" }}
           - name: istio-token
             mountPath: /var/run/secrets/tokens
@@ -197,6 +199,8 @@ spec:
             mountPath: /cacerts
           {{- end }}
       volumes:
+      - emptyDir: {}
+        name: workload-socket
       # Technically not needed on this pod - but it helps debugging/testing SDS
       # Should be removed after everything works.
       - emptyDir:

--- a/pilot/pkg/bootstrap/certcontroller.go
+++ b/pilot/pkg/bootstrap/certcontroller.go
@@ -307,8 +307,7 @@ func (s *Server) loadIstiodCert() error {
 
 // init istiod certificates watches on the SPIFFE Workload API socket
 func (s *Server) initCertificatesWatchesOnSocket() error {
-	err := s.setAndNotifyIstiodCertBundleWatcher()
-	if err != nil {
+	if err := s.setAndNotifyIstiodCertBundleWatcher(); err != nil {
 		return err
 	}
 
@@ -328,9 +327,7 @@ func (s *Server) watchCertificateUpdatesOnSocket(watchCh <-chan struct{}, stopCh
 			return
 		case <-watchCh:
 			log.Info("certificates update received from socket")
-
-			err := s.setAndNotifyIstiodCertBundleWatcher()
-			if err != nil {
+			if err := s.setAndNotifyIstiodCertBundleWatcher(); err != nil {
 				log.Errorf("error setting and notifying bundle watcher: %v", err)
 			}
 		}
@@ -350,7 +347,7 @@ func (s *Server) setAndNotifyIstiodCertBundleWatcher() error {
 
 	s.istiodCertBundleWatcher.SetAndNotify(key, certChain, caBundle)
 
-	log.Infof("istiod cert chain: \n %s", certChain)
+	log.Infof("Istiod cert chain: \n %s", certChain)
 
 	return nil
 }

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -213,8 +213,7 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 	}
 
 	if features.PilotCertProvider == constants.CertProviderSocket {
-		err := s.setX509Source()
-		if err != nil {
+		if err := s.setX509Source(); err != nil {
 			return nil, fmt.Errorf("failed setting SPIFFE X.509 Source on istiod Server: %v", err)
 		}
 	}
@@ -1126,11 +1125,13 @@ func (b bundleWatcher) OnX509BundlesUpdate(s *x509bundle.Set) {
 	td, err := spiffeid.TrustDomainFromString(spiffe.GetTrustDomain())
 	if err != nil {
 		log.Errorf("error trying to parse trust domain %q reason: %v", td, err)
+		return
 	}
 
 	bundle, err := s.GetX509BundleForTrustDomain(td)
 	if err != nil {
 		log.Errorf("unable to find X.509 bundle for trust domain %q: %v", td, err)
+		return
 	}
 
 	b.peerCertVerifier.AddMapping(spiffe.GetTrustDomain(), bundle.X509Authorities())

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"net"
 	"net/http"
 	"os"
@@ -173,6 +175,10 @@ type Server struct {
 	statusManager  *status.Manager
 	// RWConfigStore is the configstore which allows updates, particularly for status.
 	RWConfigStore model.ConfigStoreController
+
+	// x509Source is a source of SPIFFE X.509 certs and X.509 bundles maintained via the SPIFFE Workload API.
+	// It's used when the PilotCertProvider is configured to 'socket'.
+	x509Source *spiffe.X509Source
 }
 
 // NewServer creates a new Server instance based on the provided arguments.
@@ -205,6 +211,14 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 	for _, fn := range initFuncs {
 		fn(s)
 	}
+
+	if features.PilotCertProvider == constants.CertProviderSocket {
+		err := s.setX509Source()
+		if err != nil {
+			return nil, fmt.Errorf("failed setting SPIFFE X.509 Source on istiod Server: %v", err)
+		}
+	}
+
 	// Initialize workload Trust Bundle before XDS Server
 	e.TrustBundle = s.workloadTrustBundle
 	s.XDSServer = xds.NewDiscoveryServer(e, args.PodName, args.RegistryOptions.KubeOptions.ClusterAliases)
@@ -350,6 +364,17 @@ func NewServer(args *PilotArgs, initFuncs ...func(*Server)) (*Server, error) {
 	})
 
 	return s, nil
+}
+
+func (s *Server) setX509Source() error {
+	ctx := context.Background()
+	x509Source, err := spiffe.NewX509Source(ctx, security.WorkloadIdentitySocketPath)
+	if err != nil {
+		return err
+	}
+
+	s.x509Source = x509Source
+	return nil
 }
 
 func initOIDC(args *PilotArgs, trustDomain string) (security.Authenticator, error) {
@@ -712,6 +737,12 @@ func (s *Server) waitForShutdown(stop <-chan struct{}) {
 
 		// Shutdown the DiscoveryServer.
 		s.XDSServer.Shutdown()
+
+		if s.x509Source != nil {
+			if err := s.x509Source.Close(); err != nil {
+				log.Warn(err)
+			}
+		}
 	}()
 }
 
@@ -983,6 +1014,12 @@ func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
 			return nil
 		}
 		err = s.initIstiodCertLoader()
+	} else if features.PilotCertProvider == constants.CertProviderSocket {
+		log.Infof("using external socket to get Istiod certificates")
+		err = s.initCertificatesWatchesOnSocket()
+		if err == nil {
+			err = s.initIstiodCertLoader()
+		}
 	} else if features.PilotCertProvider == constants.CertProviderNone {
 		return nil
 	} else if s.EnableCA() && features.PilotCertProvider == constants.CertProviderIstiod {
@@ -1010,7 +1047,7 @@ func (s *Server) initIstiodCerts(args *PilotArgs, host string) error {
 
 // createPeerCertVerifier creates a SPIFFE certificate verifier with the current istiod configuration.
 func (s *Server) createPeerCertVerifier(tlsOptions TLSOptions) (*spiffe.PeerCertVerifier, error) {
-	if tlsOptions.CaCertFile == "" && s.CA == nil && features.SpiffeBundleEndpoints == "" && !s.isDisableCa() {
+	if tlsOptions.CaCertFile == "" && s.CA == nil && features.SpiffeBundleEndpoints == "" && !s.isDisableCa() && features.PilotCertProvider != constants.CertProviderSocket {
 		// Running locally without configured certs - no TLS mode
 		return nil, nil
 	}
@@ -1052,7 +1089,57 @@ func (s *Server) createPeerCertVerifier(tlsOptions TLSOptions) (*spiffe.PeerCert
 		peerCertVerifier.AddMappings(certMap)
 	}
 
+	if features.PilotCertProvider == constants.CertProviderSocket {
+		caBundle, err := s.x509Source.GetCaBundleForTrustDomain(spiffe.GetTrustDomain())
+		if err != nil {
+			return nil, fmt.Errorf("error gettting CA Bundle for trust domain %v: %v", spiffe.GetTrustDomain(), err)
+		}
+
+		peerCertVerifier.AddMapping(spiffe.GetTrustDomain(), caBundle.X509Authorities())
+
+		// start watcher to keep receiving X.509 bundle updates and add them to the peerCertVerifier
+		s.addStartFunc(func(stop <-chan struct{}) error {
+			go func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				watcher := bundleWatcher{peerCertVerifier}
+				err := spiffe.WatchX509Bundles(ctx, security.WorkloadIdentitySocketPath, watcher)
+				if err != nil {
+					log.Errorf("error starting X.509 Bundle watcher for Pilot: %v", err)
+				}
+				<-stop
+			}()
+			return nil
+		})
+	}
+
 	return peerCertVerifier, nil
+}
+
+// implements workloadapi.X509BundleWatcher interface.
+type bundleWatcher struct {
+	peerCertVerifier *spiffe.PeerCertVerifier
+}
+
+// OnX509BundlesUpdate gets the X.509 bundle updates and adds them to the peerCertVerifier.
+func (b bundleWatcher) OnX509BundlesUpdate(s *x509bundle.Set) {
+	td, err := spiffeid.TrustDomainFromString(spiffe.GetTrustDomain())
+	if err != nil {
+		log.Errorf("error trying to parse trust domain %q reason: %v", td, err)
+	}
+
+	bundle, err := s.GetX509BundleForTrustDomain(td)
+	if err != nil {
+		log.Errorf("unable to find X.509 bundle for trust domain %q: %v", td, err)
+	}
+
+	b.peerCertVerifier.AddMapping(spiffe.GetTrustDomain(), bundle.X509Authorities())
+
+	log.Info("new CA bundles added to peerCertVerifier")
+}
+
+func (b bundleWatcher) OnX509BundlesWatchError(e error) {
+	log.Errorf("error receiving the new CA bundles: %v", e)
 }
 
 // hasCustomTLSCerts returns true if custom TLS certificates are configured via args.

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -140,4 +140,6 @@ const (
 	// CertProviderNone does not create any certificates for the control plane. It is assumed that some external
 	// load balancer, such as an Istio Gateway, is terminating the TLS.
 	CertProviderNone = "none"
+	// CertProviderSocket uses the socket mounted in a well known location to fetch the certificates for the control plane
+	CertProviderSocket = "socket"
 )

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -34,8 +34,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 
+	"google.golang.org/grpc/credentials/insecure"
 	mesh "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/cmd/pilot-agent/config"
 	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
@@ -49,6 +49,7 @@ import (
 	"istio.io/istio/pkg/envoy"
 	"istio.io/istio/pkg/istio-agent/grpcxds"
 	"istio.io/istio/pkg/security"
+	"istio.io/istio/pkg/spiffe"
 	"istio.io/istio/pkg/util/protomarshal"
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/istio/security/pkg/nodeagent/caclient"
@@ -128,6 +129,10 @@ type Agent struct {
 
 	// Signals true completion (e.g. with delayed graceful termination of Envoy)
 	wg sync.WaitGroup
+
+	// x509Source is a source of SPIFFE X.509 certs and X.509 bundles maintained via the SPIFFE Workload API.
+	// It's used when the PilotCertProvider is configured to 'socket'.
+	x509Source *spiffe.X509Source
 }
 
 // AgentOptions contains additional config for the agent, not included in ProxyConfig.
@@ -237,7 +242,7 @@ func (a *Agent) generateNodeMetadata() (*model.Node, error) {
 		return nil, fmt.Errorf("failed to find root CA cert for XDS: %v", err)
 	}
 
-	if provCert == "" {
+	if provCert == "" && a.secOpts.PilotCertProvider != constants.CertProviderSocket {
 		// Envoy only supports load from file. If we want to use system certs, use best guess
 		// To be more correct this could lookup all the "well known" paths but this is extremely \
 		// unlikely to run on a non-debian based machine, and if it is it can be explicitly configured
@@ -430,6 +435,13 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 		}
 	}
 
+	if a.secOpts.PilotCertProvider == constants.CertProviderSocket {
+		err := a.setX509Source(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error setting SPIFFE X.509 Source on Agent: %v", err)
+		}
+	}
+
 	a.xdsProxy, err = initXdsProxy(a)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start xds proxy: %v", err)
@@ -491,6 +503,16 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 		}()
 	}
 	return a.wg.Wait, nil
+}
+
+func (a *Agent) setX509Source(ctx context.Context) error {
+	x509Source, err := spiffe.NewX509Source(ctx, security.WorkloadIdentitySocketPath)
+	if err != nil {
+		return err
+	}
+
+	a.x509Source = x509Source
+	return nil
 }
 
 func (a *Agent) initSdsServer() error {
@@ -668,6 +690,11 @@ func (a *Agent) close() {
 	if a.caFileWatcher != nil {
 		_ = a.caFileWatcher.Close()
 	}
+	if a.x509Source != nil {
+		if err := a.x509Source.Close(); err != nil {
+			log.Warn(err)
+		}
+	}
 }
 
 // FindRootCAForXDS determines the root CA to be configured in bootstrap file.
@@ -702,6 +729,9 @@ func (a *Agent) FindRootCAForXDS() (string, error) {
 		rootCAPath = a.proxyConfig.ProxyMetadata[MetadataClientRootCert]
 	} else if a.secOpts.PilotCertProvider == constants.CertProviderNone {
 		return "", fmt.Errorf("root CA file for XDS required but configured provider as none")
+	} else if a.secOpts.PilotCertProvider == constants.CertProviderSocket {
+		// returns empty path and no error as the RootCA for XDS will be fetched from the socket
+		return "", nil
 	} else {
 		// PILOT_CERT_PROVIDER - default is istiod
 		// This is the default - a mounted config map on K8S

--- a/pkg/istio-agent/agent.go
+++ b/pkg/istio-agent/agent.go
@@ -436,8 +436,7 @@ func (a *Agent) Run(ctx context.Context) (func(), error) {
 	}
 
 	if a.secOpts.PilotCertProvider == constants.CertProviderSocket {
-		err := a.setX509Source(ctx)
-		if err != nil {
+		if err := a.setX509Source(ctx); err != nil {
 			return nil, fmt.Errorf("error setting SPIFFE X.509 Source on Agent: %v", err)
 		}
 	}
@@ -692,7 +691,7 @@ func (a *Agent) close() {
 	}
 	if a.x509Source != nil {
 		if err := a.x509Source.Close(); err != nil {
-			log.Warn(err)
+			log.Warnf("Error closing SPIFFE X.509 source: %v", err)
 		}
 	}
 }

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -110,7 +110,7 @@ func (x *X509Source) GetCertificateChainAndKey() ([]byte, []byte, error) {
 func (x *X509Source) GetCaBundleForTrustDomain(td string) (*x509bundle.Bundle, error) {
 	trustDomain, err := spiffeid.TrustDomainFromString(td)
 	if err != nil {
-		return nil, fmt.Errorf("error trying to parse trust domain %q reason: %v", td, err)
+		return nil, fmt.Errorf("error trying to parse trust domain %q: %v", td, err)
 	}
 
 	bundle, err := x.x509Source.GetX509BundleForTrustDomain(trustDomain)
@@ -130,7 +130,7 @@ func (x *X509Source) GetCaBundlePEMForTrustDomain(td string) ([]byte, error) {
 
 	bundleBytes, err := bundle.Marshal()
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal X.509 byndle: %v", err)
+		return nil, fmt.Errorf("unable to marshal X.509 bundle: %v", err)
 	}
 	return bundleBytes, nil
 }

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -159,7 +159,7 @@ func WatchX509Bundles(ctx context.Context, socketPath string, bundleWatcher work
 	return nil
 }
 
-// Normalizes a socket path making it absolute and adding the unix:// prefix if missing.
+// Normalizes a socket path by making it absolute and adding the unix:// prefix if missing.
 // Note: go-spiffe library doesn't accept relative socket paths nor paths without unix:// prefix.
 func normalizeSocketPath(socketPath string) (string, error) {
 	abs, err := filepath.Abs(socketPath)


### PR DESCRIPTION
**Please provide a description of this PR:**
This PR adds a new option for the provisioning of certificates to the Istio Control Plane through the use of the `SPIFFE Workload API` listening on a socket.

To enable this new functionality it's used the configuration: `pilotCertProvider: "socket"`. ("socket" is a new config value defined in this PR).

Istiod and the istio-agents connect on the already defined socket path to fetch their identity materials and use these certificates to do mTLS in the Control Plane. 

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

Signed-off-by: Max Lambrecht <max.lambrecht@hpe.com>